### PR TITLE
chore: update dependencies, remove workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,23 +28,13 @@ Example:
 
 JDK 11 or higher must be installed.
 
-This plugin currently depends on an unreleased version on JADX. Therefore, you have to build the latest version of JADX:
-
-```bash
-git clone https://github.com/skylot/jadx.git
-cd jadx
-JADX_VERSION="1.5.1-SNAPSHOT" ./gradlew publishToMavenLocal
-```
-
-(on Windows, use gradlew.bat instead of ./gradlew)
-
-#### Build the plugin
-
 ```bash
 git clone https://github.com/jadx-decompiler/jadx-android-linter-plugin.git
 cd jadx-android-linter-plugin
 ./gradlew assemble
 ```
+
+(on Windows, use gradlew.bat instead of ./gradlew)
 
 ### Install
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 	// auto update dependencies with 'useLatestVersions' task
 	id("se.patrikerdes.use-latest-versions") version "0.2.18"
-	id("com.github.ben-manes.versions") version "0.50.0"
+	id("com.github.ben-manes.versions") version "0.51.0"
 }
 
 dependencies {
@@ -24,7 +24,7 @@ dependencies {
 	}
 	compileOnly("com.google.code.gson:gson:2.11.0")
 	compileOnly("commons-io:commons-io:2.17.0")
-	compileOnly("ch.qos.logback:logback-classic:1.5.8")
+	compileOnly("ch.qos.logback:logback-classic:1.5.11")
 
 	testImplementation("io.github.skylot:jadx-core:1.5.1-SNAPSHOT") {
 		isChanging = true
@@ -33,19 +33,19 @@ dependencies {
 		isChanging = true
 	}
 	testImplementation("com.google.code.gson:gson:2.11.0")
-	testImplementation("ch.qos.logback:logback-classic:1.5.8")
+	testImplementation("ch.qos.logback:logback-classic:1.5.11")
 	testImplementation("org.apache.commons:commons-lang3:3.17.0")
 	testImplementation("jakarta.xml.bind:jakarta.xml.bind-api:4.0.2")
-	testImplementation("org.ow2.asm:asm:9.7")
+	testImplementation("org.ow2.asm:asm:9.7.1")
 	testRuntimeOnly("com.sun.xml.bind:jaxb-impl:4.0.5")
 
 	testImplementation("io.github.skylot:jadx-smali-input:1.5.1-SNAPSHOT") {
 		isChanging = true
 	}
 
-	testImplementation("org.assertj:assertj-core:3.24.2")
-	testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.1")
-	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.1")
+	testImplementation("org.assertj:assertj-core:3.26.3")
+	testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.2")
+	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.11.2")
 }
 
 allprojects {


### PR DESCRIPTION
Changes in this PR:
- keep versions in sync with JADX
- updated README to remove workaround